### PR TITLE
[UCR-679] Komodo/ucr 679

### DIFF
--- a/oci_env/cleanup_and_recreate_dummy_resources.sh
+++ b/oci_env/cleanup_and_recreate_dummy_resources.sh
@@ -6,12 +6,12 @@ set -e
 USERNAME="admin"
 PASSWORD="password"
 BASE_URL_V3="http://localhost:5001/pulp/api/v3"
-BASE_ULR_HOST="http://localhost:5001"
+BASE_URL_HOST="http://localhost:5001"
 
 # Function to delete a resource
 delete_resource() {
     local resource_url=$1
-    local delete_url="$BASE_ULR_HOST$resource_url"
+    local delete_url="$BASE_URL_HOST$resource_url"
     echo "Deleting $delete_url"
     curl -u $USERNAME:$PASSWORD -X DELETE "$delete_url"
 }
@@ -85,19 +85,19 @@ repo_href=$(echo $repo_response | jq -r '.pulp_href')
 echo "Created repository: $repo_href"
 
 # Sync repository
-sync_response=$(curl -u $USERNAME:$PASSWORD -X POST "${BASE_ULR_HOST}${repo_href}sync/" \
+sync_response=$(curl -u $USERNAME:$PASSWORD -X POST "${BASE_URL_HOST}${repo_href}sync/" \
     -H "Content-Type: application/json" \
     -d "{
           \"remote\": \"$remote_href\",
           \"mirror\": true
         }")
 sync_task=$(echo $sync_response | jq -r '.task')
-echo "Started sync task: $BASE_ULR_HOST$sync_task"
+echo "Started sync task: $BASE_URL_HOST$sync_task"
 
 # Wait for sync to complete
 sync_status=""
 while [[ "$sync_status" != "completed" ]]; do
-    sync_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_ULR_HOST$sync_task" | jq -r '.state')
+    sync_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$sync_task" | jq -r '.state')
     echo "Sync status: $sync_status"
     sleep 5
 done
@@ -109,18 +109,18 @@ pub_response=$(curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/publications/r/
           \"repository_version\": \"${repo_href}versions/1/\"
         }")
 pub_task_href=$(echo $pub_response | jq -r '.task')
-echo "Started publication task: $BASE_ULR_HOST$pub_task_href"
+echo "Started publication task: $BASE_URL_HOST$pub_task_href"
 
 # Wait for publication to complete
 pub_status=""
 while [[ "$pub_status" != "completed" ]]; do
-    pub_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_ULR_HOST$pub_task_href" | jq -r '.state')
+    pub_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$pub_task_href" | jq -r '.state')
     echo "Publication status: $pub_status"
     sleep 5
 done
 
 # Extract the publication href from the task response
-pub_href=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_ULR_HOST$pub_task_href" | jq -r '.created_resources[0]')
+pub_href=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$pub_task_href" | jq -r '.created_resources[0]')
 echo "Created publication: $pub_href"
 
 # Create a distribution from the publication
@@ -136,14 +136,14 @@ distribution_task_href=$(echo $dist_response | jq -r '.task')
 # Wait for distribution to complete
 distribution_status=""
 while [[ "$distribution_status" != "completed" ]]; do
-    distribution_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_ULR_HOST$distribution_task_href" | jq -r '.state')
+    distribution_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$distribution_task_href" | jq -r '.state')
     echo "Distribution status: $distribution_status"
     sleep 5
 done
 
 # Extract the distribution href from the task response
-distribution_href=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_ULR_HOST$distribution_task_href" | jq -r '.created_resources[0]')
+distribution_href=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$distribution_task_href" | jq -r '.created_resources[0]')
 echo "Created distribution: $distribution_href"
 
 # Get distribution details
-curl -u $USERNAME:$PASSWORD -X GET "$BASE_ULR_HOST$distribution_href"
+curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$distribution_href"

--- a/oci_env/download_r_package.sh
+++ b/oci_env/download_r_package.sh
@@ -57,7 +57,7 @@ R --version
 BASE_URL="http://localhost:5001/pulp/api/v3/content/r"
 
 # The name of the R package to install
-PACKAGE_NAME="BLRShiny"
+PACKAGE_NAME="ggplot2"
 
 # R command to install the package from the specified repository
 R_COMMAND="options(verbose = TRUE); tryCatch(

--- a/oci_env/upload_r_package.sh
+++ b/oci_env/upload_r_package.sh
@@ -56,11 +56,10 @@ upload_package() {
     response=$(curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_HOST$repo_href"upload_content/ \
         -H "Content-Type: multipart/form-data" \
         -F "file=@$package_file" \
-        -F "artifact=@$package_file" \
         -F "relative_path=dummy_package/dummy_0.1.0.tar.gz" \
         -F "url=http://example.com/dummy_package/dummy_0.1.0.tar.gz" \
         -F "name=dummy" \
-        -F "version=0.1.1" \
+        -F "version=0.1.5" \
         -F "priority=" \
         -F "summary=A Dummy R Package" \
         -F "description=This is a dummy R package created for testing purposes." \
@@ -95,23 +94,56 @@ publish_repository() {
     repo_version_href=$(curl -u $USERNAME:$PASSWORD -X GET "$repo_href"versions/ \
         | jq -r '.results | sort_by(.number) | last | .pulp_href')
 
-    curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/publications/r/r/" \
+    pub_response=$(curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/publications/r/r/" \
         -H "Content-Type: application/json" \
-        -d "{\"repository_version\": \"$repo_version_href\"}"
+        -d "{\"repository_version\": \"$repo_version_href\"}")
+
+    pub_task_href=$(echo $pub_response | jq -r '.task')
+    echo "Started publication task: $BASE_URL_HOST$pub_task_href"
+
+    # Wait for publication to complete
+    pub_status=""
+    while [[ "$pub_status" != "completed" ]]; do
+        pub_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$pub_task_href" | jq -r '.state')
+        echo "Publication status: $pub_status"
+        sleep 5
+    done
+
+    # Extract the publication href from the task response
+    pub_href=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$pub_task_href" | jq -r '.created_resources[0]')
+    echo "Created publication: $pub_href"
+
+    echo $pub_href
 }
 
 # Function to create a distribution
 create_distribution() {
     local pub_href=$1
 
-    curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/distributions/r/r/" \
+    dist_response=$(curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/distributions/r/r/" \
         -H "Content-Type: application/json" \
         -d "{
               \"name\": \"R Package Distribution\",
               \"base_path\": \"$DISTRIBUTION_BASE_PATH\",
               \"publication\": \"$pub_href\"
-            }"
+            }")
+
+    distribution_task_href=$(echo $dist_response | jq -r '.task')
+    echo "Started distribution task: $BASE_URL_HOST$distribution_task_href"
+
+    # Wait for distribution to complete
+    distribution_status=""
+    while [[ "$distribution_status" != "completed" ]]; do
+        distribution_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$distribution_task_href" | jq -r '.state')
+        echo "Distribution status: $distribution_status"
+        sleep 5
+    done
+
+    # Extract the distribution href from the task response
+    distribution_href=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$distribution_task_href" | jq -r '.created_resources[0]')
+    echo "Created distribution: $distribution_href"
 }
+
 # Create a dummy R package
 create_dummy_package
 package_file="$temp_dir/dummy_package/dummy_0.1.0.tar.gz"
@@ -141,32 +173,10 @@ echo "Created repository: $repo_href"
 upload_package $package_file $repo_href
 
 # Publish the repository
-pub_response=$(publish_repository "$repo_href")
-pub_href=$(echo $pub_response | jq -r '.pulp_href')
-echo "Published repository: $pub_href"
-
-# Wait for publication to complete
-pub_task_href=$(echo $pub_response | jq -r '.task')
-pub_status=""
-while [[ "$pub_status" != "completed" ]]; do
-    pub_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$pub_task_href" | jq -r '.state')
-    echo "Publication status: $pub_status"
-    sleep 5
-done
+pub_href=$(publish_repository "$repo_href")
 
 # Create a distribution
-dist_response=$(create_distribution $pub_href)
-dist_href=$(echo $dist_response | jq -r '.pulp_href')
-echo "Created distribution: $dist_href"
-
-# Wait for distribution to complete
-distribution_task_href=$(echo $dist_response | jq -r '.task')
-distribution_status=""
-while [[ "$distribution_status" != "completed" ]]; do
-    distribution_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$distribution_task_href" | jq -r '.state')
-    echo "Distribution status: $distribution_status"
-    sleep 5
-done
+create_distribution $pub_href
 
 # Install the package from the Pulp repository
 R -e "install.packages('dummy', repos='$PACKAGE_CONTENT_URL')"

--- a/oci_env/upload_r_package.sh
+++ b/oci_env/upload_r_package.sh
@@ -60,7 +60,7 @@ upload_package() {
         -F "relative_path=dummy_package/dummy_0.1.0.tar.gz" \
         -F "url=http://example.com/dummy_package/dummy_0.1.0.tar.gz" \
         -F "name=dummy" \
-        -F "version=0.1.0" \
+        -F "version=0.1.1" \
         -F "priority=" \
         -F "summary=A Dummy R Package" \
         -F "description=This is a dummy R package created for testing purposes." \

--- a/oci_env/upload_r_package.sh
+++ b/oci_env/upload_r_package.sh
@@ -6,7 +6,7 @@ set -e
 USERNAME="admin"
 PASSWORD="password"
 BASE_URL_V3="http://localhost:5001/pulp/api/v3"
-BASE_ULR_HOST="http://localhost:5001"
+BASE_URL_HOST="http://localhost:5001"
 DISTRIBUTION_BASE_PATH="r/src/contrib"
 PACKAGE_CONTENT_URL="$BASE_URL_V3/content/$DISTRIBUTION_BASE_PATH"
 
@@ -53,18 +53,51 @@ upload_package() {
     local package_file=$1
     local repo_href=$2
 
-    curl -u $USERNAME:$PASSWORD -X POST "$BASE_ULR_HOST$repo_href"upload_content/ \
+    response=$(curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_HOST$repo_href"upload_content/ \
         -H "Content-Type: multipart/form-data" \
-        -F "file=@$package_file"
+        -F "file=@$package_file" \
+        -F "artifact=@$package_file" \
+        -F "relative_path=dummy_package/dummy_0.1.0.tar.gz" \
+        -F "url=http://example.com/dummy_package/dummy_0.1.0.tar.gz" \
+        -F "name=dummy" \
+        -F "version=0.1.0" \
+        -F "priority=" \
+        -F "summary=A Dummy R Package" \
+        -F "description=This is a dummy R package created for testing purposes." \
+        -F "license=MIT" \
+        -F "md5sum=" \
+        -F "path=" \
+        -F "depends=[]" \
+        -F "imports=[]" \
+        -F "suggests=[]" \
+        -F "requires=[]" \
+        -F "needs_compilation=false" \
+        -w "\n%{http_code}" )
+
+    http_code=$(echo "$response" | tail -n1)
+    response_body=$(echo "$response" | sed '$d')
+
+    echo "Response: $response_body"
+
+    if [[ "$http_code" -ge 200 && "$http_code" -lt 300 ]]; then
+        echo "Upload successful."
+    else
+        echo "Upload failed with status code $http_code."
+        exit 1
+    fi
 }
 
 # Function to publish the repository
 publish_repository() {
     local repo_href=$1
 
+    # Get the latest repository version href
+    repo_version_href=$(curl -u $USERNAME:$PASSWORD -X GET "$repo_href"versions/ \
+        | jq -r '.results | sort_by(.number) | last | .pulp_href')
+
     curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/publications/r/r/" \
         -H "Content-Type: application/json" \
-        -d "{\"repository\": \"$repo_href\"}"
+        -d "{\"repository_version\": \"$repo_version_href\"}"
 }
 
 # Function to create a distribution
@@ -79,7 +112,6 @@ create_distribution() {
               \"publication\": \"$pub_href\"
             }"
 }
-
 # Create a dummy R package
 create_dummy_package
 package_file="$temp_dir/dummy_package/dummy_0.1.0.tar.gz"
@@ -113,10 +145,28 @@ pub_response=$(publish_repository "$repo_href")
 pub_href=$(echo $pub_response | jq -r '.pulp_href')
 echo "Published repository: $pub_href"
 
+# Wait for publication to complete
+pub_task_href=$(echo $pub_response | jq -r '.task')
+pub_status=""
+while [[ "$pub_status" != "completed" ]]; do
+    pub_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$pub_task_href" | jq -r '.state')
+    echo "Publication status: $pub_status"
+    sleep 5
+done
+
 # Create a distribution
 dist_response=$(create_distribution $pub_href)
 dist_href=$(echo $dist_response | jq -r '.pulp_href')
 echo "Created distribution: $dist_href"
+
+# Wait for distribution to complete
+distribution_task_href=$(echo $dist_response | jq -r '.task')
+distribution_status=""
+while [[ "$distribution_status" != "completed" ]]; do
+    distribution_status=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_HOST$distribution_task_href" | jq -r '.state')
+    echo "Distribution status: $distribution_status"
+    sleep 5
+done
 
 # Install the package from the Pulp repository
 R -e "install.packages('dummy', repos='$PACKAGE_CONTENT_URL')"

--- a/oci_env/upload_r_package.sh
+++ b/oci_env/upload_r_package.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+set -e
+
+# Credentials
+USERNAME="admin"
+PASSWORD="password"
+BASE_URL_V3="http://localhost:5001/pulp/api/v3"
+BASE_ULR_HOST="http://localhost:5001"
+DISTRIBUTION_BASE_PATH="r/src/contrib"
+PACKAGE_CONTENT_URL="$BASE_URL_V3/content/$DISTRIBUTION_BASE_PATH"
+
+# Create a temporary directory for the dummy package
+temp_dir=$(mktemp -d)
+trap 'rm -rf "$temp_dir"' EXIT
+
+# Function to create a dummy R package
+create_dummy_package() {
+    cd "$temp_dir"
+    mkdir -p dummy_package
+    cd dummy_package
+
+    cat > DESCRIPTION <<EOL
+Package: dummy
+Title: A Dummy R Package
+Version: 0.1.0
+Author: John Doe
+Maintainer: John Doe <john.doe@example.com>
+Description: This is a dummy R package created for testing purposes.
+License: MIT
+EOL
+
+    mkdir -p R
+    cat > R/dummy.R <<EOL
+#' A dummy function
+#'
+#' This function prints a greeting message.
+#'
+#' @param name The name of the person to greet.
+#'
+#' @export
+greet <- function(name) {
+  message(paste("Hello,", name, "!"))
+}
+EOL
+
+    R CMD build .
+    cd "$temp_dir"
+}
+
+# Function to upload the package to Pulp
+upload_package() {
+    local package_file=$1
+    local repo_href=$2
+
+    curl -u $USERNAME:$PASSWORD -X POST "$BASE_ULR_HOST$repo_href"upload_content/ \
+        -H "Content-Type: multipart/form-data" \
+        -F "file=@$package_file"
+}
+
+# Function to publish the repository
+publish_repository() {
+    local repo_href=$1
+
+    curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/publications/r/r/" \
+        -H "Content-Type: application/json" \
+        -d "{\"repository\": \"$repo_href\"}"
+}
+
+# Function to create a distribution
+create_distribution() {
+    local pub_href=$1
+
+    curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/distributions/r/r/" \
+        -H "Content-Type: application/json" \
+        -d "{
+              \"name\": \"R Package Distribution\",
+              \"base_path\": \"$DISTRIBUTION_BASE_PATH\",
+              \"publication\": \"$pub_href\"
+            }"
+}
+
+# Create a dummy R package
+create_dummy_package
+package_file="$temp_dir/dummy_package/dummy_0.1.0.tar.gz"
+
+# Generate a unique repository name by appending a timestamp
+timestamp=$(date +%s)
+repo_name="R Package Repository $timestamp"
+
+# Create a new repository
+repo_response=$(curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/repositories/r/r/" \
+    -H "Content-Type: application/json" \
+    -d "{
+          \"name\": \"$repo_name\",
+          \"description\": \"Repository for R packages\"
+        }")
+
+if [[ $(echo $repo_response | jq -r '.pulp_href') == "null" ]]; then
+    echo "Failed to create repository. Server response:"
+    echo $repo_response
+    exit 1
+fi
+
+repo_href=$(echo $repo_response | jq -r '.pulp_href')
+echo "Created repository: $repo_href"
+
+# Upload the package to the repository
+upload_package $package_file $repo_href
+
+# Publish the repository
+pub_response=$(publish_repository "$repo_href")
+pub_href=$(echo $pub_response | jq -r '.pulp_href')
+echo "Published repository: $pub_href"
+
+# Create a distribution
+dist_response=$(create_distribution $pub_href)
+dist_href=$(echo $dist_response | jq -r '.pulp_href')
+echo "Created distribution: $dist_href"
+
+# Install the package from the Pulp repository
+R -e "install.packages('dummy', repos='$PACKAGE_CONTENT_URL')"
+
+# Use the installed package
+R -e "library(dummy); greet('Pulp')"

--- a/oci_env/upload_r_package.sh
+++ b/oci_env/upload_r_package.sh
@@ -7,8 +7,8 @@ USERNAME="admin"
 PASSWORD="password"
 BASE_URL_V3="http://localhost:5001/pulp/api/v3"
 BASE_URL_HOST="http://localhost:5001"
-DISTRIBUTION_BASE_PATH="tenantx/r/src/contrib"
-CONTENT_INDEX_PATH="content/tenantx/r"
+DISTRIBUTION_BASE_PATH="r/tenantx/src/contrib"
+CONTENT_INDEX_PATH="content/r/tenantx"
 PACKAGE_CONTENT_URL="$BASE_URL_V3/$CONTENT_INDEX_PATH"
 
 # Create a temporary directory for the dummy package
@@ -139,7 +139,7 @@ echo "Created publication: $pub_href"
 
 
 # Check if a distribution with the same base_path already exists
-existing_dist=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_V3/distributions/r/r/?base_path=r/src/contrib" | jq -r '.results[0].pulp_href')
+existing_dist=$(curl -u $USERNAME:$PASSWORD -X GET "$BASE_URL_V3/distributions/r/r/?base_path=$DISTRIBUTION_BASE_PATH" | jq -r '.results[0].pulp_href')
 
 if [[ $existing_dist != "null" ]]; then
     # Update the existing distribution
@@ -153,7 +153,7 @@ else
     dist_response=$(curl -u $USERNAME:$PASSWORD -X POST "$BASE_URL_V3/distributions/r/r/" \
         -H "Content-Type: application/json" \
         -d "{
-              \"name\": \"CRAN Distribution\",
+              \"name\": \"CRAN Distribution tenantx\",
               \"base_path\": \"$DISTRIBUTION_BASE_PATH\",
               \"publication\": \"$pub_href\"
             }")

--- a/oci_env/upload_r_package.sh
+++ b/oci_env/upload_r_package.sh
@@ -63,7 +63,7 @@ upload_package() {
         -F "relative_path=$package_name/${package_name}_0.1.0.tar.gz" \
         -F "url=http://example.com/$package_name/${package_name}_0.1.0.tar.gz" \
         -F "name=$package_name" \
-        -F "version=0.1.1" \
+        -F "version=0.1.0" \
         -F "priority=" \
         -F "summary=A Dummy R Package" \
         -F "description=This is a dummy R package created for testing purposes." \

--- a/pulp_r/app/serializers.py
+++ b/pulp_r/app/serializers.py
@@ -125,3 +125,10 @@ class RDistributionSerializer(platform.DistributionSerializer):
 
     def get_packages_url(self, obj):
         return f'{obj.base_path}/src/contrib/PACKAGES.gz'
+
+    def validate(self, data):
+        try:
+            return super().validate(data)
+        except Exception as e:
+            logger.error(f"Validation error in RDistributionSerializer: {str(e)}")
+            raise

--- a/pulp_r/app/serializers.py
+++ b/pulp_r/app/serializers.py
@@ -50,7 +50,8 @@ class RPackageSerializer(platform.SingleArtifactContentSerializer):
     def create(self, validated_data):
         file = validated_data.pop('file')
         artifact = Artifact.init_and_validate(file.name, file)
-        package = models.RPackage.objects.create(**validated_data)
+        artifact.save()  # Save the artifact to generate its ID
+        package = models.RPackage.objects.create(artifact=artifact, **validated_data)
         ContentArtifact.objects.create(
             artifact=artifact,
             content=package,

--- a/pulp_r/app/viewsets.py
+++ b/pulp_r/app/viewsets.py
@@ -170,6 +170,18 @@ class RRepositoryViewSet(core.RepositoryViewSet, ModifyRepositoryActionMixin):
     queryset = models.RRepository.objects.all()
     serializer_class = serializers.RRepositorySerializer
     http_method_names = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']
+    
+    @action(detail=True, methods=["post"], serializer_class=serializers.RPackageSerializer)
+    def upload_content(self, request, pk):
+        repository = self.get_object()
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        package = serializer.save()
+
+        # Associate the package with the repository
+        repository.content.add(package)
+
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @extend_schema(
         description="Trigger an asynchronous task to sync content.",

--- a/pulp_r/app/viewsets.py
+++ b/pulp_r/app/viewsets.py
@@ -265,3 +265,10 @@ class RDistributionViewSet(core.DistributionViewSet):
     queryset = models.RDistribution.objects.all()
     serializer_class = serializers.RDistributionSerializer
     http_method_names = ['get', 'post', 'put', 'patch', 'delete', 'head', 'options']
+
+    def create(self, request, *args, **kwargs):
+        try:
+            return super().create(request, *args, **kwargs)
+        except Exception as e:
+            logger.error(f"Error creating distribution: {str(e)}")
+            raise


### PR DESCRIPTION
# Changes
- Add `upload_r_package` script
- Update `RPackage` and `RRepositoryViewSet` Serializer and Viewsets to handle content uploads

# Test
- Run `./oci_env/bootstrap_server.sh` to start server
- Run `./oci_env/upload_r_package.sh` to upload package

## Result:

```

➜ ./oci_env/upload_r_package.sh
* checking for file ‘./DESCRIPTION’ ... OK
* preparing ‘dummy171753459412788’:
* checking DESCRIPTION meta-information ... OK
* checking for LF line-endings in source and make files and shell scripts
* checking for empty or unneeded directories
* creating default NAMESPACE file
* building ‘dummy171753459412788_0.1.0.tar.gz’

  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   635  100   518  100   117   3247    733 --:--:-- --:--:-- --:--:--  4096
Created repository: /pulp/api/v3/repositories/r/r/018fe50a-166e-73b1-93dc-b2e5ce196353/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  2577  100    67  100  2510    426  15962 --:--:-- --:--:-- --:--:-- 16843
Response: {"task":"/pulp/api/v3/tasks/018fe50a-172d-7c24-81f6-3ed7aff69f8c/"}
Upload successful.
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   861  100   861    0     0   6300      0 --:--:-- --:--:-- --:--:--  6473
Task status: completed
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   861  100   861    0     0   5047      0 --:--:-- --:--:-- --:--:--  5218
Created publication: /pulp/api/v3/publications/r/r/018fe50a-1746-7d29-8897-db11436fd3d6/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   598  100   598    0     0   4706      0 --:--:-- --:--:-- --:--:--  4822
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   181  100    67  100   114    483    822 --:--:-- --:--:-- --:--:--  1340
Started distribution task: http://localhost:5001/pulp/api/v3/tasks/018fe50a-2d3d-747f-aa2c-b5687e472dab/
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   822  100   822    0     0   6287      0 --:--:-- --:--:-- --:--:--  6472
Distribution status: completed

Platform: aarch64-apple-darwin23.4.0

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> install.packages('dummy171753459412788', repos='http://localhost:5001/pulp/api/v3/content/r/tenantx')
Installing package into ‘/opt/homebrew/lib/R/4.4/site-library’
(as ‘lib’ is unspecified)
trying URL 'http://localhost:5001/pulp/api/v3/content/r/tenantx/src/contrib/dummy171753459412788_0.1.0.tar.gz'
Content type 'application/gzip' length 593 bytes
==================================================
downloaded 593 bytes

* installing *source* package ‘dummy171753459412788’ ...
** using staged installation
** R
** byte-compile and prepare package for lazy loading
** help
No man pages found in package  ‘dummy171753459412788’ 
*** installing help indices
** building package indices
** testing if installed package can be loaded from temporary location
** testing if installed package can be loaded from final location
** testing if installed package keeps a record of temporary installation path
* DONE (dummy171753459412788)

The downloaded source packages are in
        ‘/private/var/folders/hy/81vb5s157nvgrvldtk12bwzm0000gq/T/RtmpW6dl5e/downloaded_packages’
> 
> 

R version 4.4.0 (2024-04-24) -- "Puppy Cup"
Copyright (C) 2024 The R Foundation for Statistical Computing
Platform: aarch64-apple-darwin23.4.0

R is free software and comes with ABSOLUTELY NO WARRANTY.
You are welcome to redistribute it under certain conditions.
Type 'license()' or 'licence()' for distribution details.

  Natural language support but running in an English locale

R is a collaborative project with many contributors.
Type 'contributors()' for more information and
'citation()' on how to cite R or R packages in publications.

Type 'demo()' for some demos, 'help()' for on-line help, or
'help.start()' for an HTML browser interface to help.
Type 'q()' to quit R.

> library(dummy171753459412788); greet('Pulp')
Hello, Pulp !
> 
> 
```